### PR TITLE
Fix swapped FPGA_SPI and FLASH_SPI pins

### DIFF
--- a/port/ucontroller/nxp/lpc17xx/lpc17_ssp.c
+++ b/port/ucontroller/nxp/lpc17xx/lpc17_ssp.c
@@ -31,14 +31,14 @@
 
 static ssp_config_t ssp_cfg[MAX_SSP_INTERFACES] = {
     [FPGA_SPI] = {
-        .lpc_id = LPC_SSP0,
-        .irq = SSP0_IRQn,
-        .ssel_pin = SSP0_SSEL,
-    },
-    [FLASH_SPI] = {
         .lpc_id = LPC_SSP1,
         .irq = SSP1_IRQn,
         .ssel_pin = SSP1_SSEL,
+    },
+    [FLASH_SPI] = {
+        .lpc_id = LPC_SSP0,
+        .irq = SSP0_IRQn,
+        .ssel_pin = SSP0_SSEL,
     }
 };
 


### PR DESCRIPTION
This PR fixes an error in the pin mapping for initialising the SSP interfaces. According to the schematics ([Sayma-AMC v2.0.1](https://github.com/sinara-hw/Sayma_AMC/releases/download/v2.0.1/Sayma_AMC.PDF), page 5) and [pin_mapping.h](https://github.com/sinara-hw/openMMC/blob/sayma-devel/port/board/sayma/pin_mapping.h) of this branch, the CPU-to-FPGA SPI interface uses SSP1, while the optional flash storage MT25QL256 uses SSP0.

Because I couldn't reprogram the CPU via USB FTDI and I haven't tried using the JTAG interface directly at this moment, this has not been tested on real hardware. No matter, this PR should be consistent with the latest schematics.

### Related work

Part of https://github.com/m-labs/artiq/issues/1604.