### PR TITLE
Fix EUI48 read from EEPROM

### DIFF
--- a/modules/fpga_spi.c
+++ b/modules/fpga_spi.c
@@ -79,8 +79,9 @@ void vTaskFPGA_COMM( void * Parameters )
 
     /* Initialize diagnostic struct with static data */
 
-    /* Read Card ID from EEPROM (4 bytes) */
-    at24mac_read_eui(CHIP_ID_EEPROM, (uint8_t *)&diag->cardID[0], 4,  10);
+    /* Read Card ID from EEPROM (6 bytes) */
+    /* Note that the EUI48 spans from cardID[0] to cardID[1] */
+    at24mac_read_eui(CHIP_ID_EEPROM, (uint8_t *)&diag->cardID[0], 6,  10);
 
     /* AMC IPMI address */
     diag->ipmi_addr = ipmb_addr;


### PR DESCRIPTION
This PR fixes a possible oversight on reading EUI48 from the AT24MAC EEPROM. It is a 6 byte value and, according to the [datasheet](http://ww1.microchip.com/downloads/en/devicedoc/Atmel-8807-SEEPROM-AT24MAC402-602-Datasheet.pdf), the whole value must be read from the beginning memory address of `9Ah` (see paragraph above Figure 12-5, p.21). However, the current code only read the first 4 bytes as unsigned 32-bit int, which seems to ignore the last 2 bytes that are the unique ID.

This fix should be safe to run. Inside the `board_diagnostic_t` struct, the `cardID` field storing the EUI48 is a 32-bit int array of length 4, so storing the 6 bytes from this I2C read means EUI48[31:0] are stored in `cardID[0]` and EUI[47:32] are stored in bits[15:0] of `cardID[1]` (and in little-endian).

This has not been tested on real hardware, but should behave as expected on one.

### Related work

Part of https://github.com/m-labs/artiq/issues/1604. When FPGA reads from CPU, since the EUI48 spans 2 addresses (`0x00`, `0x01`), it must receive two SPI write operations (from the CPU perspective) to fetch the entire EUI48.